### PR TITLE
Picking bugs to fix

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -3,7 +3,7 @@
 ## Bugs
 
 ### Definition
-We define a bug as any experience that breaks the _intended_ functionality of a user experience in [Tilt](https://docs.tilt.dev/), including [Tilt Cloud](https://cloud.tilt.dev/). In particular, we may have shipped a feature that failed to meet a certain user's expectation, but that may not necessarily qualify as a bug. In this case, we may should nonetheless track the user problem as a non-bug to improve Tilt.
+We define a bug as any experience that breaks the _intended_ functionality of a user experience in [Tilt](https://docs.tilt.dev/), including [Tilt Cloud](https://cloud.tilt.dev/). In particular, we may have shipped a feature that failed to meet a certain user's expectation, but that may not necessarily qualify as a bug. In this case, we should nonetheless track the user problem as a non-bug to improve Tilt.
 
 We should express our intentions through [documentating Tilt functionality](https://docs.tilt.dev/) exhaustively, to better support users and manage their expectations.
 

--- a/development/README.md
+++ b/development/README.md
@@ -22,7 +22,8 @@ The [Exterminator](../user-support/README.md#exterminator) is responsible for tr
 Tilters should regularly assign bugs for themselves to fix. A good rule of thumb is to fix two bugs after you have finished working on an [epic](../product-development/README.md#picking-an-epic-to-work-on) (whether as the DRI or a collaborator), before moving on to the next epic.
 
 ### Pick a high priority bug
-When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns.
+When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns. 
+If a bug cannot be fixed within a day or two, consider creating a more thorough plan (possibly [creating an epic to track it](../product-development/README.md#defining-high-level-business-initiatives-with-clubhouse-epics)) and consulting with other Tilters, before beginning the work.
 
 ### Close associated GitHub issue
 If the bug you have fixed is logged as a GitHub issue (in addition to being logged as a Clubhouse story, which it should already have been), be sure to close the GitHub issue, preferably with a link to the pull request fix, helping inform external users that the bug has now been fixed.

--- a/development/README.md
+++ b/development/README.md
@@ -28,6 +28,6 @@ When picking a bug to work on, Tilters are encouraged to pick a high priority bu
 If the bug you have fixed is logged as a GitHub issue (in addition to being logged as a Clubhouse story, which it should already have been), be sure to close the GitHub issue, preferably with a link to the pull request fix, helping inform external users that the bug has now been fixed.
 
 ## Metrics
-Extracting data from Clubhouse (by [exporting all stories](https://help.clubhouse.io/hc/en-us/articles/360021168791-CSV-Export) from the single project we use), we track the number of bugs created, number of bugs fixed, and the total number of open bugs, over time. Note that the total number of open bugs is impacted by created bugs, bugs fixed, non-bugs being converted to bugs, and bugs being converted to non-bugs. So the week over week change of total number of bugs is not only impacted by bugs created and bugs fixed.
+Extracting data from Clubhouse (by [exporting all stories](https://help.clubhouse.io/hc/en-us/articles/360021168791-CSV-Export) from the single project we use), we track the number of bugs created, number of bugs fixed, and the total number of open bugs, over time. Note that open bugs is impacted by bugs created, bugs fixed, non-bugs being converted to bugs, and bugs being converted to non-bugs. So the week over week change of open bugs is not only impacted by bugs created and bugs fixed.
 
 See charts and data in the [Google sheet](https://docs.google.com/spreadsheets/d/13L7Yg4x5lDCwevwVbzNJjMW_sLQxBZj73CuFlC_vkV8/).

--- a/development/README.md
+++ b/development/README.md
@@ -19,7 +19,7 @@ We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Til
 The [Exterminator](../user-support/README.md#exterminator) is responsible for triaging user support requests, including bugs. The Exterminator may fix a bug themself, or assign another Tilter to fix it, coordinating appropriate people and circumstances.
 
 ### Assign yourself a bug
-Tilters should regularly assign themself to fix bugs. A good rule of thumb is to fix two bugs after you have finished working on an [epic](../product-development/README.md#picking-an-epic-to-work-on), whether as the DRI or a collaborator, before moving on to the next epic.
+Tilters should regularly assign bugs for themselves to fix. A good rule of thumb is to fix two bugs after you have finished working on an [epic](../product-development/README.md#picking-an-epic-to-work-on) (whether as the DRI or a collaborator), before moving on to the next epic.
 
 ### Pick a high priority bug
 When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns.

--- a/development/README.md
+++ b/development/README.md
@@ -1,11 +1,19 @@
 # Development
 
-## Bug
+## Bugs
+
+### Bug definition
 We define a bug as any experience that breaks the _intended_ functionality of a user experience in [Tilt](https://docs.tilt.dev/), including [Tilt Cloud](https://cloud.tilt.dev/). In particular, we may have shipped a feature that failed to meet a certain user's expectation, but that may not necessarily qualify as a bug. In this case, we may should nonetheless track the user problem as a non-bug to improve Tilt.
 
 We should express our intentions through [documentating Tilt functionality](https://docs.tilt.dev/) exhaustively, to better support users and manage their expectations.
 
 Non-user facing problems are not classified as bugs.
 
-## Tracking work
-See the higher-level [Product Development workflow](../product-development/README.md#workflow) workflow focused on prioritizing and solving business problems. This section is focused on tracking more granular development work on a daily and weekly basis.
+### All bugs
+
+All known open bugs should be listed in the [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs). Some bugs are also listed in [GitHub issues](https://github.com/windmilleng/tilt/labels/bug). But these should be a subset of the entire set of open bugs in the Clubhouse space.
+
+
+
+
+#### Anytime

--- a/development/README.md
+++ b/development/README.md
@@ -17,3 +17,11 @@ We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Til
 
 ### Exterminator assigns bugs
 The [Exterminator](../user-support/README.md) is responsible triaging user support requests, including bugs. The Exterminator may fix a bug themself, or assign another Tilter to fix, coordinating appropriate people and circumstances.
+
+### Assign yourself a bug
+Tilters should regularly fix bugs. A good rule of thumb is to fix two bugs after you have finished working on an [epic](../product-development/README.md#picking-an-epic-to-work-on), whether as the DRI or a collaborator, before moving on to the next epic.
+
+### Pick a high priority bug
+When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns.
+
+

--- a/development/README.md
+++ b/development/README.md
@@ -12,7 +12,7 @@ Non-user facing problems are not classified as bugs.
 ### All bugs
 All known open bugs should be listed in the [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs). Some bugs are also listed in [GitHub issues](https://github.com/windmilleng/tilt/labels/bug). But these should be a subset of the entire set of open bugs in the Clubhouse space.
 
-### Fix a bug at anytime
+### Fix a bug at any time
 We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Tilters are encouraged to use their own judgment in picking up a bug to fix at anytime, if they think it's the best use of their time at that moment, ahead of other priorities. Nobody should ever need permission to fix a bug.
 
 ### Exterminator assigns bugs

--- a/development/README.md
+++ b/development/README.md
@@ -23,3 +23,6 @@ Tilters should regularly assign bugs for themselves to fix. A good rule of thumb
 
 ### Pick a high priority bug
 When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns.
+
+### Close associated GitHub issue
+If the bug you have fixed is logged as a GitHub issue (in addition to being logged as a Clubhouse story, which it should already have been), be sure to close the GitHub issue, preferably with a link to the pull request fix, helping inform external users that the bug has now been fixed.

--- a/development/README.md
+++ b/development/README.md
@@ -16,10 +16,10 @@ All known open bugs should be listed in the [Bugs Clubhouse space](https://app.c
 We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Tilters are encouraged to use their own judgment in picking up a bug to fix at anytime, if they think it's the best use of their time at that moment, ahead of other priorities. Nobody should ever need permission to fix a bug.
 
 ### Exterminator assigns bugs
-The [Exterminator](../user-support/README.md) is responsible triaging user support requests, including bugs. The Exterminator may fix a bug themself, or assign another Tilter to fix, coordinating appropriate people and circumstances.
+The [Exterminator](../user-support/README.md#exterminator) is responsible for triaging user support requests, including bugs. The Exterminator may fix a bug themself, or assign another Tilter to fix it, coordinating appropriate people and circumstances.
 
 ### Assign yourself a bug
-Tilters should regularly fix bugs. A good rule of thumb is to fix two bugs after you have finished working on an [epic](../product-development/README.md#picking-an-epic-to-work-on), whether as the DRI or a collaborator, before moving on to the next epic.
+Tilters should regularly assign themself to fix bugs. A good rule of thumb is to fix two bugs after you have finished working on an [epic](../product-development/README.md#picking-an-epic-to-work-on), whether as the DRI or a collaborator, before moving on to the next epic.
 
 ### Pick a high priority bug
 When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns.

--- a/development/README.md
+++ b/development/README.md
@@ -28,6 +28,6 @@ When picking a bug to work on, Tilters are encouraged to pick a high priority bu
 If the bug you have fixed is logged as a GitHub issue (in addition to being logged as a Clubhouse story, which it should already have been), be sure to close the GitHub issue, preferably with a link to the pull request fix, helping inform external users that the bug has now been fixed.
 
 ## Metrics
-Extracting data from Clubhouse (by [exporting all stories](https://help.clubhouse.io/hc/en-us/articles/360021168791-CSV-Export) from the single project we use), we track the number of bugs created, number of bugs fixed, and the total number of open bugs, over time. Note that open bugs is impacted by bugs created, bugs fixed, non-bugs being converted to bugs, and bugs being converted to non-bugs. So the week over week change of open bugs is not only impacted by bugs created and bugs fixed.
+Extracting data from Clubhouse (by [exporting all stories](https://help.clubhouse.io/hc/en-us/articles/360021168791-CSV-Export) from the single project we use), we track the number of bugs created, number of bugs closed, and the total number of open bugs, over time. Note that open bugs is impacted by bugs created, bugs closed, non-bugs being converted to bugs, and bugs being converted to non-bugs. So the week over week change of open bugs is not only impacted by bugs created and bugs closed.
 
 See charts and data in the [Google sheet](https://docs.google.com/spreadsheets/d/13L7Yg4x5lDCwevwVbzNJjMW_sLQxBZj73CuFlC_vkV8/).

--- a/development/README.md
+++ b/development/README.md
@@ -26,3 +26,8 @@ When picking a bug to work on, Tilters are encouraged to pick a high priority bu
 
 ### Close associated GitHub issue
 If the bug you have fixed is logged as a GitHub issue (in addition to being logged as a Clubhouse story, which it should already have been), be sure to close the GitHub issue, preferably with a link to the pull request fix, helping inform external users that the bug has now been fixed.
+
+## Metrics
+Extracting data from Clubhouse (by [exporting all stories](https://help.clubhouse.io/hc/en-us/articles/360021168791-CSV-Export) from the single project we use), we track the number of bugs created, number of bugs fixed, and the total number of open bugs, over time. Note that the total number of open bugs is impacted by created bugs, bugs fixed, non-bugs being converted to bugs, and bugs being converted to non-bugs. So the week over week change of total number of bugs is not only impacted by bugs created and bugs fixed.
+
+See charts and data in the [Google sheet](https://docs.google.com/spreadsheets/d/13L7Yg4x5lDCwevwVbzNJjMW_sLQxBZj73CuFlC_vkV8/).

--- a/development/README.md
+++ b/development/README.md
@@ -13,7 +13,7 @@ Non-user facing problems are not classified as bugs.
 All known open bugs should be listed in the [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs). Some bugs are also listed in [GitHub issues](https://github.com/windmilleng/tilt/labels/bug). But these should be a subset of the entire set of open bugs in the Clubhouse space.
 
 ### Fix a bug at anytime
-We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Tilters are encouraged to use their own judgment in picking up a bug to fix at anytime, if they think it's the best use of their time at that moment, ahead of other priorities. Nobody should ever need experience to fix a bug.
+We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Tilters are encouraged to use their own judgment in picking up a bug to fix at anytime, if they think it's the best use of their time at that moment, ahead of other priorities. Nobody should ever need permission to fix a bug.
 
 ### Exterminator assigns bugs
 The [Exterminator](../user-support/README.md) is responsible triaging user support requests, including bugs. The Exterminator may fix a bug themself, or assign another Tilter to fix, coordinating appropriate people and circumstances.

--- a/development/README.md
+++ b/development/README.md
@@ -23,5 +23,3 @@ Tilters should regularly assign bugs for themselves to fix. A good rule of thumb
 
 ### Pick a high priority bug
 When picking a bug to work on, Tilters are encouraged to pick a high priority bug that they can finish in a sensible time period for that bug. The [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs) has higher priority bugs toward the top of columns.
-
-

--- a/development/README.md
+++ b/development/README.md
@@ -2,7 +2,7 @@
 
 ## Bugs
 
-### Bug definition
+### Definition
 We define a bug as any experience that breaks the _intended_ functionality of a user experience in [Tilt](https://docs.tilt.dev/), including [Tilt Cloud](https://cloud.tilt.dev/). In particular, we may have shipped a feature that failed to meet a certain user's expectation, but that may not necessarily qualify as a bug. In this case, we may should nonetheless track the user problem as a non-bug to improve Tilt.
 
 We should express our intentions through [documentating Tilt functionality](https://docs.tilt.dev/) exhaustively, to better support users and manage their expectations.
@@ -10,10 +10,10 @@ We should express our intentions through [documentating Tilt functionality](http
 Non-user facing problems are not classified as bugs.
 
 ### All bugs
-
 All known open bugs should be listed in the [Bugs Clubhouse space](https://app.clubhouse.io/windmill/stories/space/4729/bugs). Some bugs are also listed in [GitHub issues](https://github.com/windmilleng/tilt/labels/bug). But these should be a subset of the entire set of open bugs in the Clubhouse space.
 
+### Fix a bug at anytime
+We believe in shipping a quality experience for both Tilt and Tilt Cloud. So Tilters are encouraged to use their own judgment in picking up a bug to fix at anytime, if they think it's the best use of their time at that moment, ahead of other priorities. Nobody should ever need experience to fix a bug.
 
-
-
-#### Anytime
+### Exterminator assigns bugs
+The [Exterminator](../user-support/README.md) is responsible triaging user support requests, including bugs. The Exterminator may fix a bug themself, or assign another Tilter to fix, coordinating appropriate people and circumstances.

--- a/product-development/README.md
+++ b/product-development/README.md
@@ -26,7 +26,7 @@ Anyone advocating for an epic's priority (or priorities in general) should @-men
 <img src="images/epics-priority.png" height="100" />
 
 ## Picking an epic to work on
-When a Tilt engineer is free, they should [pick a high priority unstarted epic](#picking-a-high-priority-unstarted-epic) to work on, or join another engineer (or engineers) already working on an `In Progress` epic. Engineers should self-organize and coordinate timelines ad hoc when picking epics. There are no stable teams, no timeboxed sprints, and no synced sprints across teams. Engineers should consider:
+When a Tilt engineer is free, they should [pick a high priority unstarted epic](#picking-a-high-priority-unstarted-epic) to work on, or join another engineer (or engineers) already working on an `In Progress` epic. (They might consider [fixing a bug instead](../development/README.md#assign-yourself-a-bug).) Engineers should self-organize and coordinate timelines ad hoc when picking epics. There are no stable teams, no timeboxed sprints, and no synced sprints across teams. Engineers should consider:
 - Working in at least pairs on a given epic, to better facilitate product and code collaboration, avoiding working in siloes.
 - Having a dedicated review Tilter per epic, who may be responsible for code review, content review and/or general deliverable review, who may not necessarily be collaborating during the design and implementation part of the epic, but is responsible for reviewing work.
 - Not working on too many epics concurrently, in order to focus on a smaller number of tasks to reduce context-switching.


### PR DESCRIPTION
The purpose of this PR is to codify a process to regularly fix bugs (at least the ones recorded in Clubhouse), in order to keep the number of bugs under control. I.e. the number of bugs should not grow without bound, and we should try to keep the bug count constant, and aim to reduce it over time.

Not all bugs are created equal, in terms of severity (Sev 1, 2, 3, ...) and in terms of effort to fix. But this is a first pass effort in defining a light weight bug fix process that takes the bug count as a heuristic measure of the bugginess of Tilt and Tilt Cloud. If in the future we want to quantify both bug severity (and possibly SLAs) and fix effort, we can. But for now, a simple bug count I think suffices. This PR also links to a google sheet tracking bug counts. See https://docs.google.com/spreadsheets/d/13L7Yg4x5lDCwevwVbzNJjMW_sLQxBZj73CuFlC_vkV8/edit#gid=371930451.

As Maia noted on March 23, 2020, not all bugs are tracked in Clubhouse (i.e. Clubhouse stories marked with the bug story type). Some are in GitHub issues (not in Clubhouse) or in Clubhouse but not marked as bug. This is a first pass at least addressing any bug type stories that are in Clubhouse. We may want to do a better job of getting _all_ bugs exhaustively recorded in Clubhouse. But that can be a subsequent effort that builds on this PR (and thus shouldn't block it).

I (Victor) presume that showstopping bugs (i.e. really bad ones) are already being fixed. And may or may not be recorded in Clubhouse. So this PR doesn't address that or try to improve that because presumably it's already being addressed. The purpose of this PR is to better analyze any quality problems in Tilt and Tilt Cloud that we may be not directly addressing, and try to drive the bug count of Clubhouse bugs toward zero over time.